### PR TITLE
Fix HintStatusLine typo in statusline module

### DIFF
--- a/lua/hydra/hint/statusline.lua
+++ b/lua/hydra/hint/statusline.lua
@@ -72,6 +72,6 @@ end
 
 --------------------------------------------------------------------------------
 
-M.intStatusLine = HintStatusLine
+M.HintStatusLine = HintStatusLine
 M.HintStatusLineMute = HintStatusLineMute
 return M


### PR DESCRIPTION
Currently [1] is broken.

```
E5113: Error while calling lua chunk: ...ck/.vim/plugged/hydra.nvim/lua/hydra/hint/init.lua:28: attempt to call upvalue 'HintStatusLine' (a nil value)
stack traceback:
        ...ck/.vim/plugged/hydra.nvim/lua/hydra/hint/init.lua:28: in function 'hint'
        ...ederick/.vim/plugged/hydra.nvim/lua/hydra/init.lua:179: in function 'initialize'
        ...ck/.vim/plugged/hydra.nvim/lua/hydra/lib/class.lua:14: in function 'Hydra'
        /Users/frederick/.vim/lua/user/hydra.lua:4: in main chunk
```

[1] https://github.com/anuvyklack/hydra.nvim/blob/4fb56bf5b597e468197b94042bec4217a6c08e9c/lua/hydra/hint/init.lua#L11
