### PR TITLE
Wraps keymap unset in pcall safety

### DIFF
--- a/lua/hydra/layer/init.lua
+++ b/lua/hydra/layer/init.lua
@@ -428,7 +428,7 @@ function Layer:_restore_keymaps()
                      nowait = map.nowait
                   })
                else
-                  local status, _ = pcall(vim.keymap.del, mode, lhs, { buffer = bufnr})
+                  pcall(vim.keymap.del, mode, lhs, { buffer = bufnr })
                end
             end
          end

--- a/lua/hydra/layer/init.lua
+++ b/lua/hydra/layer/init.lua
@@ -428,7 +428,7 @@ function Layer:_restore_keymaps()
                      nowait = map.nowait
                   })
                else
-                  vim.keymap.del(mode, lhs, { buffer = bufnr })
+                  local status, _ = pcall(vim.keymap.del, mode, lhs, { buffer = bufnr})
                end
             end
          end


### PR DESCRIPTION
Wraps `vim.keymap.del` in pcall

If (for some reason) the keymap is not available to delete, vim will raise an error to the user. Does the user _really_ care that the keymap that we are trying to remove is already gone when we try to delete it?

Tangentially related to #55 (though does not directly or indirectly address it)