### PR TITLE
fix(util): some keycodes not work

### DIFF
--- a/lua/hydra/lib/util.lua
+++ b/lua/hydra/lib/util.lua
@@ -26,6 +26,9 @@ end
 ---@param keys string
 ---@return string
 function util.termcodes(keys)
+   if vim.fn.has('nvim-0.7.0') then
+       return keys
+   end
    return vim.api.nvim_replace_termcodes(keys, true, true, true) --[[@as string]]
 end
 


### PR DESCRIPTION
Mapping the `function key` key does not work, and some other keys are not mapped correctly either, such as <M-... >
After `nvim-0.7.0`, `vim.keymap.set` will automatically convert keycodes, so I added a version judgment to avoid unsuccessful mapping #51 