### PR TITLE
adding check for timeoutlen option

### DIFF
--- a/lua/hydra/health.lua
+++ b/lua/hydra/health.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+vim.health.report_start("Hydra: Checking settings")
+
+local function check_timeoutlen_option()
+	-- check timeoutlen
+	if vim.o.timeoutlen < 300 then
+		local message = [[
+            Your current `timeoutlen` value is %d which might be too small to
+            make each mapping working!
+            It's recommended to use %d for the `timeoutlen` option!
+        ]]
+		vim.health.report_warn(message:format(vim.o.timeoutlen, 300))
+	else
+		local message = [[
+            `timeoutlen` (value: %d) is set to a good value.
+        ]]
+
+		vim.health.report_ok(message:format(vim.o.timeoutlen))
+	end
+end
+
+M.check = function()
+	check_timeoutlen_option()
+end
+
+return M


### PR DESCRIPTION
When I used hydra for the first time and setup a "debuggin-layer" some keys
didn't respond at all and it seems like that the culprit was my `timeoutlen`
setting. Maybe a checkhealth could have avoid this (or at least would help to
debug this issue probably).
