### PR TITLE
fix(lib/highlight): Ignore invalid highlight keys

### DIFF
--- a/lua/hydra/lib/highlight.lua
+++ b/lua/hydra/lib/highlight.lua
@@ -3,7 +3,13 @@ local api = vim.api
 local function get_hl(name)
    ---@type boolean
    local rgb = api.nvim_get_option('termguicolors')
-   return api.nvim_get_hl_by_name(name, rgb)
+   local result = {}
+   for key, value in pairs(api.nvim_get_hl_by_name(name, rgb)) do
+      if type(key) == 'string' then
+         result[key] = value
+      end
+   end
+   return result
 end
 
 local name, settings


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3e0c066`](https://github.com/anuvyklack/hydra.nvim/pull/75/commits/3e0c066a62a9ae93132221d8901151ef2dd5c381) fix(lib/highlight): Ignore invalid highlight keys

If a user sets colour scheme to default after Neovim starts,
nvim_get_hl_by_name('HydraRed', true) returns { [true] = 6 }. This
causes an 'invalid key' error later when it's used in nvim_set_hl().

It is quite a rare case, and it should be fine as long as we can avoid
the error, so that Hydra still functions.


<!-- === GH HISTORY FENCE === -->

Fixes #70
