### PR TITLE
fix(hint): nolazyredraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ config = {
 }
 ```
 
+The default config uses `on_enter` to set `vim.o.lazyredraw = false`, since
+`lazyredraw` can interfere with the redering of some hints.
+
 #### `on_key`
 parent table: `config`
 

--- a/lua/hydra/init.lua
+++ b/lua/hydra/init.lua
@@ -30,6 +30,9 @@ local default_config = {
    color = 'red',
    timeout = false,
    invoke_on_body = false,
+   on_enter = function()
+     vim.o.lazyredraw = false
+   end,
    hint = {
       show_name = true,
       position = { 'bottom' },


### PR DESCRIPTION
Fix a rendering issue that causes the cursor to appear at the end of the hint if `lazyredraw` is enabled and hint is shown in the echo area.

### Problem

If a hydra shows its hint in the echo area (`config.hint.type = 'cmdline'`) and the user has `lazyredraw` on, the hint renders correctly when first invoked, but any subsequent action (within the hydra) causes the cursor to appear at the end of the hint.
![image](https://user-images.githubusercontent.com/1672874/218354947-eb48fded-342f-4a33-9df6-01d39e911477.png)

### Solution

Add an `on_enter` function to the default config to turn `lazyredraw` off for the duration of the hydra.
___

### Minimal reproducible example

The problem can be demonstrated (prior to this commit) by invoking nvim like,
```sh
nvim -u minimal.lua +'call append(0, "1234")' +'goto 1'
```
with the following minimal.lua init file:
```lua
vim.opt.lazyredraw = true
vim.opt.wrap = false -- allow horizontal scrolling
local hydra = require('hydra')
hydra({
  name = 'scroll',
  mode = 'n',
  body = 'z',
  heads = { { 'l', 'zl' }, { 'h', 'zh' } },
  config = { hint = { type = 'cmdline' } },
})
```
Type `zl` to invoke the hydra, and the hint is drawn correctly.
![image](https://user-images.githubusercontent.com/1672874/218354715-392de101-cd53-4a90-b0eb-b5f539f93d1c.png)

Type `l` to scroll again, and now the cursor is drawn at the end of the hint.
![image](https://user-images.githubusercontent.com/1672874/218354753-3421fc81-589b-4155-b88f-4e0beb7066d9.png)