### PR TITLE
fix(health): remove deprecated API warnings

### DIFF
--- a/lua/hydra/health.lua
+++ b/lua/hydra/health.lua
@@ -1,6 +1,10 @@
 local M = {}
 
-vim.health.report_start("Hydra: Checking settings")
+local start = vim.health.start or vim.health.report_start
+local ok = vim.health.ok or vim.health.report_ok
+local warn = vim.health.warn or vim.health.report_warn
+
+start("Hydra: Checking settings")
 
 local function check_timeoutlen_option()
 	-- check timeoutlen
@@ -10,13 +14,13 @@ local function check_timeoutlen_option()
             make each mapping working!
             It's recommended to use %d for the `timeoutlen` option!
         ]]
-		vim.health.report_warn(message:format(vim.o.timeoutlen, 300))
+		warn(message:format(vim.o.timeoutlen, 300))
 	else
 		local message = [[
             `timeoutlen` (value: %d) is set to a good value.
         ]]
 
-		vim.health.report_ok(message:format(vim.o.timeoutlen))
+		ok(message:format(vim.o.timeoutlen))
 	end
 end
 


### PR DESCRIPTION
This PR removes deprecated check health API warnings, see [here](https://neovim.io/doc/user/deprecated.html#_functions).