### PR TITLE
Add conceal function to the options hydra

### DIFF
--- a/lua/hydra/hint/vim-options.lua
+++ b/lua/hydra/hint/vim-options.lua
@@ -77,5 +77,14 @@ M.cux = function()
    end
 end
 
+M.conceal = function()
+   if vim.o.conceallevel > 0 then
+      return '[x]'
+   else
+      return '[ ]'
+   end
+end
+M.con = M.conceal
+
 return M
 


### PR DESCRIPTION
I find that when working with markdown or other concealed text, having the ability to toggle conceal is sometimes helpful, figured it would be useful in the options hydra.