### PR TITLE
add an option to add the body key to emitted foreign keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you want to quickly understand the concept, you can watch
     * [`config`](#config)
         * [`exit`](#exit)
         * [`foreign_keys`](#foreign_keys)
+        * [`prepend_body_to_foreign_keys`](#prepend_body_to_foreign_keys)
         * [`color`](#color)
             * [More about colors concept](#more-about-colors-concept)
             * [Amaranth color](#amaranth-color)
@@ -227,6 +228,23 @@ that doesn't belong to any head:
 - `foreign_keys = "warn"` will not stop the hydra state, but instead will issue a warning
   without running the foreign key.
 - `foreign_keys = "run"` will not stop the hydra state, and try to run the foreign key.
+
+#### `prepend_body_to_foreign_keys`
+`boolean`\
+default: `false`\
+parent table: `config`
+
+This option is only relevant when `foreign_keys` is set to `nil` or `run`.
+
+- `prepend_body_to_foreign_keys = false` (the default) will pass the foreign key so it
+  will do whatever it is supposed to do.
+- `prepend_body_to_foreign_keys = true` will add the body key(s) before the foreign key.
+
+The main use is to make kepmaps with the same leading body, but defined outside of this
+Hydra, reachable. For example, if you have a Hydra with the body `CTRL-W` and 4 heads
+`h`, `j`, `k`, `l`, and nothing else, then, with `prepend_body_to_foreign_keys = false`,
+when you press `v`, Hydra will pass `v` to nvim for process; on the other hand, with
+`prepend_body_to_foreign_keys = true`, Hydra will send `CTRL-W_v`.
 
 #### `color`
 `"red" | "amaranth" | "teal" | "pink"`\

--- a/doc/hydra.txt
+++ b/doc/hydra.txt
@@ -258,6 +258,28 @@ config			table
 		`foreign_keys = "run"`
 			will not stop the hydra state, and try to run the
 			foreign key.
+
+				     *hydra-config.prepend_body_to_foreign_keys*
+	prepend_body_to_foreign_keys	boolean
+					default: `false`
+					parent table: `config`
+
+		This option is only relevant when `foreign_keys=nil`.
+
+		`prepend_body_to_foreign_keys = false` (the default) will pass
+		the foreign key so it will do whatever it is supposed to do.
+
+		`prepend_body_to_foreign_keys = true` will add the body key(s)
+		before the foreign key.
+
+		The main use is to make kepmaps with the same leading body,
+		but defined outside of this Hydra, reachable. For example, if
+		you have a Hydra with the body `CTRL-W` and 4 heads `h`, `j`, `k`, `l`, and
+		nothing else, then, with `prepend_body_to_foreign_keys = false`,
+		when you press `v`, Hydra will pass `v` to nvim for process; on the
+		other hand, with `prepend_body_to_foreign_keys = true`, Hydra will
+		send `CTRL-W_v`.
+
 							    *hydra-config.color*
 	color			`"red"` | `"amaranth"` | `"teal"` | `"pink"`
 				default: `"red"`

--- a/lua/hydra/init.lua
+++ b/lua/hydra/init.lua
@@ -27,6 +27,7 @@ local default_config = {
    debug = false,
    exit = false,
    foreign_keys = nil,
+   prepend_body_to_foreign_keys = false,
    color = 'red',
    timeout = false,
    invoke_on_body = false,
@@ -53,6 +54,7 @@ function Hydra:initialize(input)
             on_enter = { input.config.on_enter, 'function', true },
             on_exit = { input.config.on_exit, 'function', true },
             exit = { input.config.exit, 'boolean', true },
+            prepend_body_to_foreign_keys = { input.config.prepend_body_to_foreign_keys, 'boolean', true },
             timeout = { input.config.timeout, { 'boolean', 'number' }, true },
             buffer = { input.config.buffer, { 'boolean', 'number' }, true },
             hint = { input.config.hint, { 'boolean', 'string', 'table' }, true },
@@ -499,6 +501,9 @@ function Hydra:_leave()
       self:_wait()
       return false
    else
+      if self.config.prepend_body_to_foreign_keys and vim.fn.getchar(1) ~= 0 then
+         api.nvim_feedkeys(termcodes(self.body), 'nix', false)
+      end
       self:exit()
       return true
    end

--- a/lua/hydra/lib/types.lua
+++ b/lua/hydra/lib/types.lua
@@ -8,6 +8,7 @@
 ---@field buffer? integer
 ---@field exit boolean
 ---@field foreign_keys hydra.foreign_keys
+---@field prepend_body_to_foreign_keys boolean
 ---@field color hydra.color
 ---@field on_enter? function  Before entering hydra
 ---@field on_exit? function   After leaving hydra


### PR DESCRIPTION
This PR adds an option `prepend_body_to_foreign_keys`, as well as related docs in help and `README.md`.

The main use is to make kepmaps with the same leading body, but defined outside of this Hydra, reachable.

For example, if you have a Hydra with the body `CTRL-W` and 4 heads
`h`, `j`, `k`, `l`, and nothing else, then, with `prepend_body_to_foreign_keys = false` (default), when you press `v`, Hydra will pass `v` to nvim for process; on the other hand, with `prepend_body_to_foreign_keys = true`, Hydra will send `CTRL-W_v`.

In practice, when we set `prepend_body_to_foreign_keys=true`, the demo config of [Windows and buffers management](https://github.com/anuvyklack/hydra.nvim/wiki/Windows-and-buffers-management):

```lua
Hydra({
   name = 'Windows',
   hint = window_hint,
   config = {
      invoke_on_body = true,
      hint = {
         border = 'rounded',
         offset = -1
      }
   },
   mode = 'n',
   body = '<C-w>',
   heads = {
      { 'h', '<C-w>h' },
      { 'j', '<C-w>j' },
      { 'k', pcmd('wincmd k', 'E11', 'close') },
      { 'l', '<C-w>l' },

      { 'H', cmd 'WinShift left' },
      { 'J', cmd 'WinShift down' },
      { 'K', cmd 'WinShift up' },
      { 'L', cmd 'WinShift right' },

      { '<C-h>', function() splits.resize_left(2)  end },
      { '<C-j>', function() splits.resize_down(2)  end },
      { '<C-k>', function() splits.resize_up(2)    end },
      { '<C-l>', function() splits.resize_right(2) end },
      { '=', '<C-w>=', { desc = 'equalize'} },

      { 's',     pcmd('split', 'E36') },
      { '<C-s>', pcmd('split', 'E36'), { desc = false } },
      { 'v',     pcmd('vsplit', 'E36') },
      { '<C-v>', pcmd('vsplit', 'E36'), { desc = false } },

      { 'w',     '<C-w>w', { exit = true, desc = false } },
      { '<C-w>', '<C-w>w', { exit = true, desc = false } },

      { 'z',     cmd 'WindowsMaximaze', { exit = true, desc = 'maximize' } },
      { '<C-z>', cmd 'WindowsMaximaze', { exit = true, desc = false } },

      { 'o',     '<C-w>o', { exit = true, desc = 'remain only' } },
      { '<C-o>', '<C-w>o', { exit = true, desc = false } },

      { 'b', choose_buffer, { exit = true, desc = 'choose buffer' } },

      { 'c',     pcmd('close', 'E444') },
      { 'q',     pcmd('close', 'E444'), { desc = 'close window' } },
      { '<C-c>', pcmd('close', 'E444'), { desc = false } },
      { '<C-q>', pcmd('close', 'E444'), { desc = false } },

      { '<Esc>', nil,  { exit = true, desc = false }}
   }
})
```
can be simplified as:

```lua
Hydra({
   name = 'Windows',
   hint = window_hint,
   config = {
      invoke_on_body = true,
      hint = {
         border = 'rounded',
         offset = -1
      },
      exit = true,  -- change here
      foreign_keys = nil,  -- change here
      prepend_body_to_foreign_keys = true,  -- change here
   },
   mode = 'n',
   body = '<C-w>',
   heads = {
      { 'H', cmd 'WinShift left', {exit = false} },
      { 'J', cmd 'WinShift down', {exit = false} },
      { 'K', cmd 'WinShift up', {exit = false} },
      { 'L', cmd 'WinShift right', {exit = false} },

      { '<C-h>', function() splits.resize_left(2)  end, {exit = false} },
      { '<C-j>', function() splits.resize_down(2)  end, {exit = false} },
      { '<C-k>', function() splits.resize_up(2)    end, {exit = false} },
      { '<C-l>', function() splits.resize_right(2) end, {exit = false} },

      { 'z',     cmd 'WindowsMaximaze', { exit = true, desc = 'maximize' } },
      { '<C-z>', cmd 'WindowsMaximaze', { exit = true, desc = false } },

      { 'b', choose_buffer, { exit = true, desc = 'choose buffer' } },

      { '<Esc>', nil,  { exit = true, desc = false }}
   }
})
```
We wouldn't need to re-define any built-in or custom keymaps here. `CTRL-W_?` is a great example, since nvim has 76 of them! This option can save us from having to repeat lots of the same patterns:
```lua
{ 'w', '<C-w>w', { exit = true, desc = false } },
```
