### PR TITLE
fix: restore eventignore from "all" to "" after showing hydra window

### DIFF
--- a/lua/hydra/hint/window.lua
+++ b/lua/hydra/hint/window.lua
@@ -108,6 +108,7 @@ function HintAutoWindow:show()
    end
    if not self.win_config then self:_make_win_config() end
 
+   local eventignore = vim.o.eventignore
    vim.o.eventignore = 'all' -- turn off autocommands
 
    local winid = api.nvim_open_win(self.buffer.id, false, self.win_config)
@@ -119,8 +120,7 @@ function HintAutoWindow:show()
    win.wo.conceallevel = 3
    win.wo.foldenable = false
    win.wo.wrap = false
-
-   vim.o.eventignore = nil -- turn on autocommands
+   vim.o.eventignore = eventignore -- turn on autocommands
 
    autocmd('TabEnter', { group = augroup, callback = function()
       if self.win:is_valid() then


### PR DESCRIPTION
It looks like `vim.o.eventignore = nil` does not work and eventignore stays with value "all", at last in my setup. Setting it to an empty string fixes the problem.